### PR TITLE
Tab/Doc/Mem

### DIFF
--- a/src/editorMode.h
+++ b/src/editorMode.h
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <ncurses.h>
+#include <error.h> 
 #include <signal.h>
 #include "fileHandler.h"
 


### PR DESCRIPTION
Worked on how tab is handled when added to the list, if ch arg is equal to '\t' we must always move x equal to _tabSize. Documentations was also added to describe the purpose of each function in editorMode.c. A general function was implemented to assert the allocations made in editorMode.c -> this should probably be used in general in this software. 