### PR TITLE
Backspace view update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,17 @@
 # oscarjfb-editor
 
-This is a terminal-based text editor
+## This is a terminal-based text editor
 
-COMMAND LIST:
+### COMMAND LIST:
  
-    	- ESC + S = save mode, which enables saving of a file. 
+    	- ESC + S = save mode, which enables saving of a file.  
  
-    	- ESC + e = exit mode, this will exit the application (without saving).
+    	- ESC + e = exit mode, this will exit the application (without saving).  
 
     	- ESC + c = copy mode, When first pressed the cursers current coordinates will be stored, once pressed again, 
-		the second curser coordinate is stored. All text between the coordinates points will be stored in a buffer. 
+		the second curser coordinate is stored. All text between the coordinates points will be stored in a buffer.  
 
     	- ESC + p = paste mode, this command will paste the buffer saved from copy mode, the buffer will remain until ESC + c is pressed again. 
 		The reason for this is to allow for multiple pastes.  
 
-BUGS/KNOWN ISSUES:
-
-	- When using KEY_DOWN at the view, on some occasions if next action is to add text, the text will be written to the newline outside of paging view.  
-
-	- Deleting a tab character may result in cursor ending up at strange location.
 	

--- a/src/editorMode.c
+++ b/src/editorMode.c
@@ -885,7 +885,7 @@ static void updateViewPort(coordinates xy, int ch, TEXT *headNode, TEXT *editedN
 	{
 		++_viewStart;
 	}
-	else if(newLines >= _view - 1 && _viewStart != 0 && ch == KEY_BACKSPACE)
+	else if(newLines >= _view - 1 && _viewStart != 0 && ch == KEY_BACKSPACE && editedNode->ch == '\n')
 	{
 		--_viewStart;
 	}


### PR DESCRIPTION
On backspace being hit, make sure the view port / paging of the text file is only update once it's an actual newline being edited/removed. This to ensure we don't change paging when deleting a regular character with backspace.